### PR TITLE
Add Node.js UDP listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ bin/org/jnetpcap/app/IpReassemblyExample.class
 bin/org/jnetpcap/app/IpReassemblyExample$1.class
 bin/org/jnetpcap/app/IpReassemblyExample$IpReassemblyBuffer.class
 bin/org/jnetpcap/app/IpReassemblyExample$IpReassemblyBufferHandler.class
+
+# Node.js artifacts
+node_modules/
+simrad_packets_*.csv

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ To use OpenBR24, follow these steps:
 2. Start the GUI class or run the .jar file provided.
 2. Choose to open a live radar ("Open Live") device or a recording ("Open File"). Recordings are read from PCAP-files. You can create your own recordings using tools like Wireshark or tcpdump.
 3. If you open a live device, turn it on using the "Power On" button. You can then select the range of the radar from the listbox. In playback mode, the range is defined by the recorded data.
+4. Optionally forward radar packets from another source using the provided Node.js script:
+   ```bash
+   node scripts/udp_listener.js
+   ```
+   The listener receives packets on UDP port `50102`, logs them to a CSV file and
+   forwards them to the multicast group `236.6.7.8:6678` so the GUI can display
+   them in real time.
 
 ## Installation
 

--- a/scripts/udp_listener.js
+++ b/scripts/udp_listener.js
@@ -1,0 +1,43 @@
+const dgram = require('dgram');
+const fs = require('fs');
+
+const LISTEN_PORT = 50102; // Port to receive on
+const FORWARD_PORT = 6678; // Port the GUI listens on
+const FORWARD_ADDR = '236.6.7.8'; // Multicast group for GUI
+const DEBUG = true; // Toggle CSV logging
+
+const listenSocket = dgram.createSocket('udp4');
+const forwardSocket = dgram.createSocket('udp4');
+
+// Setup CSV logging if DEBUG is enabled
+let csvStream = null;
+if (DEBUG) {
+  const filename = `simrad_packets_${new Date().toISOString().replace(/[:.]/g, '-')}.csv`;
+  csvStream = fs.createWriteStream(filename, { flags: 'a' });
+  csvStream.write('timestamp,length,data(hex)\n');
+  console.log(`CSV logging enabled: ${filename}`);
+}
+
+listenSocket.on('listening', () => {
+  const address = listenSocket.address();
+  console.log(`Listening for Simrad packets on ${address.address}:${address.port}`);
+});
+
+listenSocket.on('message', (msg, rinfo) => {
+  const hexData = msg.toString('hex');
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${rinfo.address}:${rinfo.port} | ${msg.length} bytes`);
+
+  if (DEBUG && csvStream) {
+    csvStream.write(`${timestamp},${msg.length},${hexData}\n`);
+  }
+
+  // forward packet to multicast group so GUI can receive it
+  forwardSocket.send(msg, 0, msg.length, FORWARD_PORT, FORWARD_ADDR, (err) => {
+    if (err) {
+      console.error('Forward error:', err);
+    }
+  });
+});
+
+listenSocket.bind(LISTEN_PORT);


### PR DESCRIPTION
## Summary
- add Node.js script to listen for radar packets and forward them to the Java GUI
- ignore node artifacts and CSV logs
- document how to use the listener in README

## Testing
- `node --version`
- `node --check scripts/udp_listener.js`
- `javac -version`


------
https://chatgpt.com/codex/tasks/task_e_6852fcb00ad08329970c9fada241d4d7